### PR TITLE
Fix BOF while copying passchar to passdisp.

### DIFF
--- a/sflock.c
+++ b/sflock.c
@@ -120,7 +120,7 @@ main(int argc, char **argv) {
 
     // fill with password characters
     for (int i = 0; i < sizeof passdisp; i+= strlen(passchar)) 
-        for (int j = 0; j < strlen(passchar); j++)
+        for (int j = 0; j < strlen(passchar) && i + j < sizeof passdisp; j++)
             passdisp[i + j] = passchar[j];
 
 


### PR DESCRIPTION
There's a buffer overflow bug while copying passchar to passdisp since the value of  i + j  is not checked.
Something bad may happen if passchar is very long, which might let a normal user get the permission of root.
