### PR TITLE
add command line switch -l to not disable console switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 sflock - simple feedback screen locker
-============================ 
+============================
+
 Simple screen locker utility for X, based on
-slock. Provides a very basic user feedback.   
+slock. Provides a very basic user feedback.
 
 
 Requirements
 ------------
+
 In order to build sflock you need the Xlib header files.
 
 
 Installation
 ------------
+
 Arch Linux users can install this package from the AUR(http://aur.archlinux.org/packages.php?ID=44802).
 
 Manual installation:
@@ -34,4 +37,5 @@ Custom settings:
 -h: toggle the bar.  
 -f <font description>: modify the font.  
 -c <password characters>: modify the characters displayed when the user enters his password. This can be a sequence of characters to create a fake password.  
+-l: do not disable switching to consoles (like Ctrl-Alt-F1). This option does not affect Xorg's DontVTSwitch .  
 

--- a/sflock.c
+++ b/sflock.c
@@ -94,8 +94,13 @@ main(int argc, char **argv) {
     char* username = ""; 
     int showline = 1;
     int xshift = 0;
+    int no_vtlock = 0;
 
     for (int i = 0; i < argc; i++) {
+        if (!strcmp(argv[i], "-l")) {
+            no_vtlock = 1;
+            continue;
+        }
         if (!strcmp(argv[i], "-c")) {
             if (i + 1 < argc) 
                 passchar = argv[i + 1];
@@ -122,7 +127,7 @@ main(int argc, char **argv) {
                         }
                         else 
                             if (!strcmp(argv[i], "?"))
-                                die("usage: sflock [-v] [-c passchars] [-f fontname] [-xshift horizontal shift]\n");
+                                die("usage: sflock [-v] [-l] [-c passchars] [-f fontname] [-xshift horizontal shift]\n");
     }
 
     // fill with password characters
@@ -136,8 +141,10 @@ main(int argc, char **argv) {
         perror("error opening console");
     }
 
-    if ((ioctl(term, VT_LOCKSWITCH)) == -1) {
-        perror("error locking console"); 
+    if (!no_vtlock) {
+        if ((ioctl(term, VT_LOCKSWITCH)) == -1) {
+            perror("error locking console"); 
+        }
     }
 
     /* deamonize */
@@ -292,8 +299,10 @@ main(int argc, char **argv) {
 
     /* free and unlock */
     setreuid(geteuid(), 0);
-    if ((ioctl(term, VT_UNLOCKSWITCH)) == -1) {
-        perror("error unlocking console"); 
+    if (!no_vtlock) {
+        if ((ioctl(term, VT_UNLOCKSWITCH)) == -1) {
+            perror("error unlocking console");
+        }
     }
 
     close(term);


### PR DESCRIPTION
Hi!

I found that for debugging purposes (and also to overcome some bugs in my window manager) it might be useful to let users to switch to the console.

My particular problem was that I switched to the console and after a timeout the sflock was activated in my X session. There was no way to switch anywhere from the current console, even after I killed sflock.

Best regards,
Alex